### PR TITLE
Fix bug BigDecimal.asInt() return incorrect value

### DIFF
--- a/Sources/BigDecimal/DecimalMath/DecimalMath.swift
+++ b/Sources/BigDecimal/DecimalMath/DecimalMath.swift
@@ -1147,8 +1147,8 @@ extension BigDecimal {
         let mc2 = Rounding(mc.mode, mc.precision+4)
         //System.out.println("logUsingExponent(" + x + " " + mathContext + ") precision " + mc);
 
-        let exponent = x.exponent
-        let mantissa = x.significand
+        let exponent = x.precision + x.exponent - 1
+        let mantissa = x.significand.scale(-x.precision+1)
 
         var result = logUsingTwoThree(mantissa, mc2)
         if exponent != 0 {

--- a/Sources/BigDecimal/DecimalMath/DecimalMath.swift
+++ b/Sources/BigDecimal/DecimalMath/DecimalMath.swift
@@ -39,7 +39,9 @@ extension BigDecimal {
         if n <= Self(I.min) { return nil }
         
         /// value must be in range of the return integer type
-        let digits = n.abs.round(Rounding(.towardZero, 0)) // truncate any fractions
+        //incorrect value, example BigDecimal("512").abs().round(Rounding(.towardZero, 0)) return 5E+2
+        //let digits = n.abs.round(Rounding(.towardZero, 0)) // truncate any fractions
+        let digits = BigDecimal.integralPart(n.abs)
         let coeff = digits.digits
         let power : BInt = BInt(10) ** digits.exponent
         if let int = (coeff * power).asInt() {

--- a/Sources/BigDecimal/DecimalMath/DecimalMath.swift
+++ b/Sources/BigDecimal/DecimalMath/DecimalMath.swift
@@ -442,7 +442,7 @@ extension BigDecimal {
         // try integral powers of y
         if fractionalPart(y) == 0 {
             if let longValue : Int = y.asInt() {
-                return x.pow(longValue).round(mc)
+                return x.pow(longValue, mc)
             } else {
                 return powInteger(x, y, mc)
             }

--- a/Tests/BigDecimalTests/TestLogarit.swift
+++ b/Tests/BigDecimalTests/TestLogarit.swift
@@ -1,0 +1,35 @@
+//
+//  TestLogarit.swift
+//  
+//
+//  Created by Nguyen ManhPhi on 22/5/24.
+//
+
+import XCTest
+import BigDecimal
+
+final class TestLogarit: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testLogarit() throws {
+        let result1 = BigDecimal.log10(BigDecimal(10.01))
+        XCTAssertEqual(result1.round(.decimal32).asString(), "1.000434")
+        let result2 = BigDecimal.log(BigDecimal(10.01))
+        XCTAssertEqual(result2.round(.decimal32).asString(), "2.303585")
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Tests/BigDecimalTests/TestPow.swift
+++ b/Tests/BigDecimalTests/TestPow.swift
@@ -1,0 +1,21 @@
+//
+//  TestPow.swift
+//  BigDecimalTests
+//
+//  Created by PhiNM on 25/05/2024.
+//
+
+import XCTest
+
+@testable import BigDecimal
+
+class TestPow: XCTestCase {
+  func testPow() throws {
+    XCTAssertEqual(BigDecimal("5.5").pow(-3, .decimal128).asString(), "0.006010518407212622088655146506386176")
+    XCTAssertEqual(BigDecimal(5.5).pow(-3, .decimal128).round(.decimal32).asString(), "0.006010518")
+    XCTAssertEqual(BigDecimal.pow(BigDecimal("5.5"), BigDecimal("-3")).asString(), "0.006010518407212622088655146506386176")    
+    XCTAssertEqual(BigDecimal("5.5").pow(3).asString(), "166.375")
+    XCTAssertEqual(BigDecimal.pow(BigDecimal("5.5"), BigDecimal("3.2")).asString(), "233.9702323679928009901371156854989")
+    XCTAssertEqual(BigDecimal.pow(BigDecimal("2"), BigDecimal("-4")).asString(), "0.0625")
+  }
+}


### PR DESCRIPTION
I encountered a bug related to the BigDecimal.asInt() function
Issue :
`BigDecimal("512").asInt()` -> return 500
Due to logic truncate any fractions :
`let digits = n.abs.round(Rounding(.towardZero, 0))`
returns the value 5E+2
It should be replaced by function or a similar truncate function:
`BigDecimal.integralPart(n.abs)`