### PR TITLE
Fix rounding error in DecimalMath.pow

### DIFF
--- a/Sources/BigDecimal/DecimalMath/DecimalMath.swift
+++ b/Sources/BigDecimal/DecimalMath/DecimalMath.swift
@@ -440,7 +440,7 @@ extension BigDecimal {
         // try integral powers of y
         if fractionalPart(y) == 0 {
             if let longValue : Int = y.asInt() {
-                return x.pow(longValue).round(mc)
+                return x.pow(longValue, mc)
             } else {
                 return powInteger(x, y, mc)
             }


### PR DESCRIPTION
The DecimalMath implementation version of pow currently calls the BigDecimal version without passing along its rounding parameter, and instead rounds the result manually. This leads to issues with infinitely repeating pow results, as BigDecimal.pow returns NaN if the result is infinitely repeating and no rounding value is passed.

For example, 5.5^-3 currently returns NaN, as 5.5^-3 = 8/1331, which is infinitely repeating.

I discovered this bug through the gamma function, which currently returns NaN for -(2k+1/2k) for any positive integer k, due to its use of DecimalMath.pow.