### PR TITLE
Fix log function error, due to incorrect calculation of exponent and mantissa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,95 @@
+# Mac
+.DS_Store
+
+Package.resolved
+
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug",
+            "program": "${workspaceFolder}/.build/debug/BigDecimalPackageTests.xctest",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Sources/BigDecimal/BigDecimal.swift
+++ b/Sources/BigDecimal/BigDecimal.swift
@@ -1278,7 +1278,7 @@ extension BigDecimal {
         } else if self.exponent < exp {
             let (q, r) = self.digits.quotientAndRemainder(dividingBy:
                                         Rounding.pow10(exp - self.exponent))
-            if r.isZero {
+            if r.isZero || q.isZero {
                 return Self(q, exp)
             }
             return Self(Rounding(mode, self.precision - self.exponent + exp)

--- a/Sources/BigDecimal/DecimalMath/DecimalMath.swift
+++ b/Sources/BigDecimal/DecimalMath/DecimalMath.swift
@@ -1148,7 +1148,7 @@ extension BigDecimal {
         //System.out.println("logUsingExponent(" + x + " " + mathContext + ") precision " + mc);
 
         let exponent = x.exponent
-        let mantissa = x.significand
+        let mantissa = x.significand.scale(-x.precision+1)
 
         var result = logUsingTwoThree(mantissa, mc2)
         if exponent != 0 {

--- a/Sources/BigDecimal/DecimalMath/DecimalMath.swift
+++ b/Sources/BigDecimal/DecimalMath/DecimalMath.swift
@@ -39,7 +39,9 @@ extension BigDecimal {
         if n <= Self(I.min) { return nil }
         
         /// value must be in range of the return integer type
-        let digits = n.abs.round(Rounding(.towardZero, 0)) // truncate any fractions
+        //incorrect value, example BigDecimal("512").abs().round(Rounding(.towardZero, 0)) return 5E+2
+        //let digits = n.abs.round(Rounding(.towardZero, 0)) // truncate any fractions
+        let digits = BigDecimal.integralPart(n.abs)
         let coeff = digits.digits
         let power : BInt = BInt(10) ** digits.exponent
         if let int = (coeff * power).asInt() {

--- a/Sources/BigDecimal/DecimalMath/DecimalMath.swift
+++ b/Sources/BigDecimal/DecimalMath/DecimalMath.swift
@@ -1147,7 +1147,7 @@ extension BigDecimal {
         let mc2 = Rounding(mc.mode, mc.precision+4)
         //System.out.println("logUsingExponent(" + x + " " + mathContext + ") precision " + mc);
 
-        let exponent = x.exponent
+        let exponent = x.precision + x.exponent - 1
         let mantissa = x.significand.scale(-x.precision+1)
 
         var result = logUsingTwoThree(mantissa, mc2)

--- a/Tests/BigDecimalTests/TestBigDecimal.swift
+++ b/Tests/BigDecimalTests/TestBigDecimal.swift
@@ -9,6 +9,7 @@
 // Test cases from Java BigDecimal tests translated to Swift
 //
 
+import Foundation
 import XCTest
 @testable import BigDecimal
 import BigInt
@@ -380,6 +381,62 @@ class TestBigDecimal: XCTestCase {
         XCTAssertEqual(x128.description, "9.999999999999999999999999999999999E+6144")
         XCTAssertEqual(y128.description, "9.999999999999999999999999999999999E-6143")
         XCTAssertEqual(z128.description, "1E-6176")
+    }
+
+    func testPrettyResult() throws {
+        let numStrings = [
+            "0.123456789",
+            "123456789.123456789",
+            "-123456789.123456789",
+            "0.000000000123456789",
+            "-123E-45",
+            "-1.23E-5",
+            "123E-45",
+            "123E-12",
+            "2E5"
+        ]
+
+        print(
+            String(
+                format: "%@%@%@%@%@%@%@", 
+                "input".padding(toLength: 25, withPad: " ", startingAt: 0), 
+                "raw".padding(toLength: 25, withPad: " ", startingAt: 0), 
+                "exponent".padding(toLength: 10, withPad: " ", startingAt: 0), 
+                "digits".padding(toLength: 20, withPad: " ", startingAt: 0), 
+                "precision".padding(toLength: 10, withPad: " ", startingAt: 0),
+                "integral".padding(toLength: 20, withPad: " ", startingAt: 0),
+                "fractional".padding(toLength: 20, withPad: " ", startingAt: 0)
+            )
+        )
+        for numString in numStrings {
+            let num = BigDecimal(numString).round(Rounding(.toNearestOrAwayFromZero, 100))
+            let input = numString.padding(toLength: 25, withPad: " ", startingAt: 0)
+            let raw = num.asString().padding(toLength: 25, withPad: " ", startingAt: 0)
+            let digits = num.digits.asString().padding(toLength: 20, withPad: " ", startingAt: 0)
+            let integral = BigDecimal.integralPart(num).asString().padding(toLength: 20, withPad: " ", startingAt: 0)
+            let fractional = BigDecimal.fractionalPart(num).asString().padding(toLength: 20, withPad: " ", startingAt: 0)
+            print(String(format: "%@%@%-10d%@%-10d%@%@", input, raw, num.exponent, digits, num.precision, integral, fractional))
+        }
+
+        let testCases : [(String, String)] = [
+            ("123456789",""),
+            ("0.123456789",""),
+            ("0.123456789",""),
+            ("0.000000000123456789",""),
+            ("123E-12",""),
+            ("",""),
+            ("",""),
+            ("",""),
+            ("",""),
+            ("","")
+        ]
+        
+        let maxIntegralLength = 6
+        let maxFractionPartLength = 3
+
+        for (number, formated) in testCases {
+            
+        }
     }
 
 }

--- a/Tests/BigDecimalTests/TestBigDecimal.swift
+++ b/Tests/BigDecimalTests/TestBigDecimal.swift
@@ -389,6 +389,8 @@ class TestBigDecimal: XCTestCase {
             "123456789.123456789",
             "-123456789.123456789",
             "0.000000000123456789",
+            "-0.0123",
+            "1000",
             "-123E-45",
             "-1.23E-5",
             "123E-45",
@@ -398,9 +400,10 @@ class TestBigDecimal: XCTestCase {
 
         print(
             String(
-                format: "%@%@%@%@%@%@%@", 
+                format: "%@%@%@%@%@%@%@%@", 
                 "input".padding(toLength: 25, withPad: " ", startingAt: 0), 
                 "raw".padding(toLength: 25, withPad: " ", startingAt: 0), 
+                "sign".padding(toLength: 5, withPad: " ", startingAt: 0), 
                 "exponent".padding(toLength: 10, withPad: " ", startingAt: 0), 
                 "digits".padding(toLength: 20, withPad: " ", startingAt: 0), 
                 "precision".padding(toLength: 10, withPad: " ", startingAt: 0),
@@ -409,13 +412,15 @@ class TestBigDecimal: XCTestCase {
             )
         )
         for numString in numStrings {
-            let num = BigDecimal(numString).round(Rounding(.toNearestOrAwayFromZero, 100))
+            let num = BigDecimal(numString)
             let input = numString.padding(toLength: 25, withPad: " ", startingAt: 0)
             let raw = num.asString().padding(toLength: 25, withPad: " ", startingAt: 0)
+            let sign = (num.sign == .plus ? "+" : "-").padding(toLength: 5, withPad: " ", startingAt: 0)
+            let exponent = num.exponent
             let digits = num.digits.asString().padding(toLength: 20, withPad: " ", startingAt: 0)
             let integral = BigDecimal.integralPart(num).asString().padding(toLength: 20, withPad: " ", startingAt: 0)
             let fractional = BigDecimal.fractionalPart(num).asString().padding(toLength: 20, withPad: " ", startingAt: 0)
-            print(String(format: "%@%@%-10d%@%-10d%@%@", input, raw, num.exponent, digits, num.precision, integral, fractional))
+            print(String(format: "%@%@%@%-10d%@%-10d%@%@", input, raw, sign, exponent, digits, num.precision, integral, fractional))
         }
 
         let testCases : [(String, String)] = [
@@ -435,7 +440,7 @@ class TestBigDecimal: XCTestCase {
         let maxFractionPartLength = 3
 
         for (number, formated) in testCases {
-            
+            let bd = BigDecimal(number)
         }
     }
 

--- a/Tests/BigDecimalTests/TestLogarit.swift
+++ b/Tests/BigDecimalTests/TestLogarit.swift
@@ -19,8 +19,10 @@ final class TestLogarit: XCTestCase {
     }
 
     func testLogarit() throws {
-        let result = BigDecimal.log10(BigDecimal(10.01))
-        XCTAssertEqual(result.round(.decimal32).asString(), "10.00043")
+        let result1 = BigDecimal.log10(BigDecimal(10.01))
+        XCTAssertEqual(result1.round(.decimal32).asString(), "1.000434")
+        let result2 = BigDecimal.log(BigDecimal(10.01))
+        XCTAssertEqual(result2.round(.decimal32).asString(), "2.303585")
     }
 
     func testPerformanceExample() throws {

--- a/Tests/BigDecimalTests/TestLogarit.swift
+++ b/Tests/BigDecimalTests/TestLogarit.swift
@@ -1,0 +1,33 @@
+//
+//  TestLogarit.swift
+//  
+//
+//  Created by Nguyen ManhPhi on 22/5/24.
+//
+
+import XCTest
+import BigDecimal
+
+final class TestLogarit: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testLogarit() throws {
+        let result = BigDecimal.log10(BigDecimal(10.01))
+        XCTAssertEqual(result.round(.decimal32).asString(), "10.00043")
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
Fix calculation of `exponent` and `mantissa`:
As function `logUsingExponent()` in [java:big-math](https://github.com/eobermuhlner/big-math/blob/b659e2f6f3f79a64d6d587c0876dac5e06870012/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigDecimalMath.java#L1011)