### PR TITLE
fix build error under swif6

### DIFF
--- a/Sources/BigDecimal/Extensions.swift
+++ b/Sources/BigDecimal/Extensions.swift
@@ -39,6 +39,7 @@ extension Array where Element == Int {
     subscript(i: UInt32) -> UInt32 { UInt32(self[Int(i)]) }
 }
 
+#if swift(>=6.0)
 extension FloatingPointClassification : @retroactive CustomStringConvertible {
   public var description: String {
     switch self {
@@ -55,6 +56,24 @@ extension FloatingPointClassification : @retroactive CustomStringConvertible {
     }
   }
 }
+#else
+extension FloatingPointClassification : CustomStringConvertible {
+  public var description: String {
+    switch self {
+      case .negativeInfinity: return "Negative Infinity"
+      case .negativeNormal: return "Negative Normal"
+      case .negativeSubnormal: return "Negative Subnormal"
+      case .negativeZero: return "Negative Zero"
+      case .positiveInfinity: return "Positive Infinity"
+      case .positiveNormal: return "Positive Normal"
+      case .positiveSubnormal: return "Positive Subnormal"
+      case .positiveZero: return "Positive Zero"
+      case .signalingNaN: return "Signaling Nan"
+      case .quietNaN: return "Quiet Nan"
+    }
+  }
+}
+#endif
 
 extension BinaryFloatingPoint {
     @inline(__always)

--- a/Sources/BigDecimal/Extensions.swift
+++ b/Sources/BigDecimal/Extensions.swift
@@ -39,8 +39,7 @@ extension Array where Element == Int {
     subscript(i: UInt32) -> UInt32 { UInt32(self[Int(i)]) }
 }
 
-#if swift(>=6.0)
-extension FloatingPointClassification : @retroactive CustomStringConvertible {
+extension FloatingPointClassification : Swift.CustomStringConvertible {
   public var description: String {
     switch self {
       case .negativeInfinity: return "Negative Infinity"
@@ -56,24 +55,6 @@ extension FloatingPointClassification : @retroactive CustomStringConvertible {
     }
   }
 }
-#else
-extension FloatingPointClassification : CustomStringConvertible {
-  public var description: String {
-    switch self {
-      case .negativeInfinity: return "Negative Infinity"
-      case .negativeNormal: return "Negative Normal"
-      case .negativeSubnormal: return "Negative Subnormal"
-      case .negativeZero: return "Negative Zero"
-      case .positiveInfinity: return "Positive Infinity"
-      case .positiveNormal: return "Positive Normal"
-      case .positiveSubnormal: return "Positive Subnormal"
-      case .positiveZero: return "Positive Zero"
-      case .signalingNaN: return "Signaling Nan"
-      case .quietNaN: return "Quiet Nan"
-    }
-  }
-}
-#endif
 
 extension BinaryFloatingPoint {
     @inline(__always)

--- a/Sources/BigDecimal/Rounding.swift
+++ b/Sources/BigDecimal/Rounding.swift
@@ -11,8 +11,7 @@ import Foundation
 /// The rounding modes
 public typealias RoundingRule = FloatingPointRoundingRule
 
-#if swift(>=6.0)
-extension RoundingRule : @retroactive CustomStringConvertible {
+extension RoundingRule : Swift.CustomStringConvertible {
     public var description: String {
         switch self {
             case .awayFromZero:
@@ -33,29 +32,6 @@ extension RoundingRule : @retroactive CustomStringConvertible {
         }
     }
 }
-#else
-extension RoundingRule : CustomStringConvertible {
-    public var description: String {
-        switch self {
-            case .awayFromZero:
-                return "Round away from 0"
-            case .down:
-                return "Round towards -infinity"
-            case .towardZero:
-                return "Round towards 0"
-            case .toNearestOrEven:
-                return "Round to nearest, ties to even"
-            case .toNearestOrAwayFromZero:
-                return "Round to nearest, ties away from 0"
-            case .up:
-                return "Round towards +infinity"
-            @unknown default:
-                assertionFailure("Unknown \(Self.self) rounding mode")
-                return ""
-        }
-    }
-}
-#endif
 /// BigDecimal rounding object containing a rounding mode and a precision
 /// which is the number of digits in the rounded result
 public struct Rounding: Equatable {

--- a/Sources/BigDecimal/Rounding.swift
+++ b/Sources/BigDecimal/Rounding.swift
@@ -11,6 +11,7 @@ import Foundation
 /// The rounding modes
 public typealias RoundingRule = FloatingPointRoundingRule
 
+#if swift(>=6.0)
 extension RoundingRule : @retroactive CustomStringConvertible {
     public var description: String {
         switch self {
@@ -32,7 +33,29 @@ extension RoundingRule : @retroactive CustomStringConvertible {
         }
     }
 }
-
+#else
+extension RoundingRule : CustomStringConvertible {
+    public var description: String {
+        switch self {
+            case .awayFromZero:
+                return "Round away from 0"
+            case .down:
+                return "Round towards -infinity"
+            case .towardZero:
+                return "Round towards 0"
+            case .toNearestOrEven:
+                return "Round to nearest, ties to even"
+            case .toNearestOrAwayFromZero:
+                return "Round to nearest, ties away from 0"
+            case .up:
+                return "Round towards +infinity"
+            @unknown default:
+                assertionFailure("Unknown \(Self.self) rounding mode")
+                return ""
+        }
+    }
+}
+#endif
 /// BigDecimal rounding object containing a rounding mode and a precision
 /// which is the number of digits in the rounded result
 public struct Rounding: Equatable {


### PR DESCRIPTION
As a result of PR #8 , It begin failing build under swift6. The reason for this is that `@retroactive` attribute is not supported for Swift6.

I fixed it by fully qualifying protocol. this is recommendation in [corresponding evolution](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md).